### PR TITLE
Support ensemble concatenation across experiments

### DIFF
--- a/config/access-cm2.yaml
+++ b/config/access-cm2.yaml
@@ -11,90 +11,42 @@ catalogs:
 
   # 2.8 TB
   bx944:
-    description: "Ensemble 1/5 of standard CMIP6 historical simulation control experiment for by473, branched from ACCESS-CM2 bi889"
+    description: "Standard CMIP6 historical simulation control experiment for by473, branched from ACCESS-CM2 bi889"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944"
-  bx944a:
-    description: "Ensemble 2/5 of standard CMIP6 historical simulation control experiment for by473a, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944a"
-  bx944b:
-    description: "Ensemble 3/5 of standard CMIP6 historical simulation control experiment for by473b, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944b"
-  bx944c:
-    description: "Ensemble 4/5 of standard CMIP6 historical simulation control experiment for by473c, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944c"
-  bx944d:
-    description: "Ensemble 5/5 of standard CMIP6 historical simulation control experiment for by473d, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/bx944d"
 
   # 0.35 TB
   by647:
-    description: "Ensemble 1/5 of standard CMIP6 ssp245 simulation control experiment for by578, branched from ACCESS-CM2 bx944 in 2015"
+    description: "Standard CMIP6 ssp245 simulation control experiment for by578, branched from ACCESS-CM2 bx944 in 2015"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by647"
-  by647a:
-    description: "Ensemble 2/5 of standard CMIP6 ssp245 simulation control experiment for by578a, branched from ACCESS-CM2 bx944a in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by647a"
-  by647b:
-    description: "Ensemble 3/5 of standard CMIP6 ssp245 simulation control experiment for by578b, branched from ACCESS-CM2 bx944b in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by647b"
-  by647c:
-    description: "Ensemble 4/5 of standard CMIP6 ssp245 simulation control experiment for by578c, branched from ACCESS-CM2 bx944c in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by647c"
-  by647d:
-    description: "Ensemble 5/5 of standard CMIP6 ssp245 simulation control experiment for by578d, branched from ACCESS-CM2 bx944d in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by647d"
 
   # 2.1 TB
   by473:
-    description: "Ensemble 1/5 of pacemaker variation of CMIP6 historical simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi889"
+    description: "Pacemaker variation of CMIP6 historical simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi889"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by473"
-  by473a:
-    description: "Ensemble 2/5 of pacemaker variation of CMIP6 historical simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by473a"
-  by473b:
-    description: "Ensemble 3/5 of pacemaker variation of CMIP6 historical simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by473b"
-  by473c:
-    description: "Ensemble 4/5 of pacemaker variation of CMIP6 historical simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by473c"
-  by473d:
-    description: "Ensemble 5/5 of pacemaker variation of CMIP6 historical simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi889"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by473d"
 
   # 0.35 GB
   by578:
-    description: "Ensemble 1/5 of pacemaker variation of CMIP6 ssp245 simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi473 in 2015"
+    description: "Pacemaker variation of CMIP6 ssp245 simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi473 in 2015"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by578"
-  by578a:
-    description: "Ensemble 2/5 of pacemaker variation of CMIP6 ssp245 simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi473a in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by578a"
-  by578b:
-    description: "Ensemble 3/5 of pacemaker variation of CMIP6 ssp245 simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi473b in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by578b"
-  by578c:
-    description: "Ensemble 4/5 of pacemaker variation of CMIP6 ssp245 simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi473c in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by578c"
-  by578d:
-    description: "Ensemble 5/5 of pacemaker variation of CMIP6 ssp245 simulation, with fixed Tropical Atlantic SSTs, branched from ACCESS-CM2 bi473d in 2015"
-    path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-CM2/by578d"
 
   # 14 TB

--- a/config/access-esm1-5.yaml
+++ b/config/access-esm1-5.yaml
@@ -14,41 +14,41 @@ catalogs:
     description: "Climate stabilization run at different global warming levels with zero C02 emissions and pre-industrial aerosols, branched from ACCESS-ESM1.5 SSP-EDC-585-13 in 2035"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/PI-GWL-B2035" 
-  PI-GWL-B2040:
+  PI_GWL_B2040:
     description: "Climate stabilization run at different global warming levels with zero C02 emissions and pre-industrial aerosols, branched from ACCESS-ESM1.5 SSP-EDC-585-13 in 2040"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/PI-GWL-B2040"
-  PI-GWL-B2045:
+  PI_GWL_B2045:
     description: "Climate stabilization run at different global warming levels with zero C02 emissions and pre-industrial aerosols, branched from ACCESS-ESM1.5 SSP-EDC-585-13 in 2045"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/PI-GWL-B2045"
-  PI-GWL-B2050:
+  PI_GWL_B2050:
     description: "Climate stabilization run at different global warming levels with zero C02 emissions and pre-industrial aerosols, branched from ACCESS-ESM1.5 SSP-EDC-585-13 in 2050"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/PI-GWL-B2050"
-  PI-GWL-B2055:
+  PI_GWL_B2055:
     description: "Climate stabilization run at different global warming levels with zero C02 emissions and pre-industrial aerosols, branched from ACCESS-ESM1.5 SSP-EDC-585-13 in 2055"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/PI-GWL-B2055"
-  PI-GWL-B2060:
+  PI_GWL_B2060:
     description: "Climate stabilization run at different global warming levels with zero C02 emissions and pre-industrial aerosols, branched from ACCESS-ESM1.5 SSP-EDC-585-13 in 2060"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/PI-GWL-B2060"
   
   # 11 TB
-  HI-C-05-r1:
+  HI_C_05_r1:
     description: "CMIP6 historical run, but with nitrogen and phosphorus limitations disabled within CASA-CNP"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/HI-C-05-r1"
-  HI-CN-05:
+  HI_CN_05:
     description: "CMIP6 historical run, but with phosphorus limitation disabled within CASA-CNP"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/HI-CN-05"
-  HI-nl-C-05-r1:
+  HI_nl_C_05_r1:
     description: "CMIP6 historical run, but with nitrogen and phosphorus limitations disabled within CASA-CNP and land-use change disabled"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/HI-nl-C-05-r1"
-  HI-noluc-CN-05:
+  HI_noluc_CN_05:
     description: "CMIP6 historical run, but with phosphorus limitation disabled within CASA-CNP and land-use change disabled"
     path:
       - "/g/data/p73/archive/non-CMIP/ACCESS-ESM1-5/HI-noluc-CN-05"

--- a/shell/build_all.sh
+++ b/shell/build_all.sh
@@ -23,7 +23,7 @@
 conda activate catalog-manager-dev
 
 CONFIG_DIR=/g/data/tm70/ds0092/projects/nri_intake_catalog/config
-CATALOG_NAME=/g/data/tm70/intake/dfcatalog_latest.csv
+CATALOG_NAME=/g/data/tm70/intake/dfcatalog.csv
 
 configs=( cmip5.yaml cmip6.yaml access-om2.yaml access-cm2.yaml access-esm1-5.yaml )
 

--- a/src/catalog_manager/__init__.py
+++ b/src/catalog_manager/__init__.py
@@ -9,6 +9,6 @@ from . import _version
 
 __version__ = _version.get_versions()["version"]
 
-here = os.path.abspath(os.path.dirname(__file__))
-cat = intake.open_catalog(os.path.join(here, "dfcatalog.yaml"))
+_here = os.path.abspath(os.path.dirname(__file__))
+cat = intake.open_catalog(os.path.join(_here, "dfcatalog.yaml"))
 data = cat.nri()

--- a/src/catalog_manager/esmcat/builders.py
+++ b/src/catalog_manager/esmcat/builders.py
@@ -216,7 +216,11 @@ class AccessOm2Builder(BaseBuilder):
                         "dim": "time",
                         "combine": "by_coords",
                     },
-                }
+                },
+                {
+                    "type": "join_new",
+                    "attribute_name": "experiment",
+                },
             ],
         )
 
@@ -239,7 +243,7 @@ class AccessOm2Builder(BaseBuilder):
                 r".*/([^/]*)/([^/]*)/output\d+/([^/]*)/.*\.nc", file
             ).groups()
             # configuration = match_groups[0]
-            # experiment = match_groups[1]
+            experiment = match_groups[1]
             realm = match_groups[2]
 
             with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
@@ -247,6 +251,7 @@ class AccessOm2Builder(BaseBuilder):
 
             info = {
                 "path": str(file),
+                "experiment": experiment,
                 "realm": realm,
                 "variable": variable_list,
                 "filename": filename,
@@ -270,7 +275,7 @@ class AccessEsm15Builder(BaseBuilder):
 
         Parameters
         ----------
-        path : str or list of str
+        path: str or list of str
             Path or list of paths to crawl for assets/files.
         """
 
@@ -289,7 +294,11 @@ class AccessEsm15Builder(BaseBuilder):
                         "dim": "time",
                         "combine": "by_coords",
                     },
-                }
+                },
+                {
+                    "type": "join_new",
+                    "attribute_name": "experiment",
+                },
             ],
         )
 
@@ -312,7 +321,7 @@ class AccessEsm15Builder(BaseBuilder):
             )
 
             match_groups = re.match(r".*/([^/]*)/history/([^/]*)/.*\.nc", file).groups()
-            # experiment = match_groups[0]
+            experiment = match_groups[0]
             realm = match_groups[1]
             if realm == "atm":
                 realm = "atmos"
@@ -326,6 +335,7 @@ class AccessEsm15Builder(BaseBuilder):
 
             info = {
                 "path": str(file),
+                "experiment": experiment,
                 "realm": realm,
                 "variable": variable_list,
                 "filename": filename,

--- a/src/catalog_manager/esmcat/builders.py
+++ b/src/catalog_manager/esmcat/builders.py
@@ -219,7 +219,7 @@ class AccessOm2Builder(BaseBuilder):
                 },
                 {
                     "type": "join_new",
-                    "attribute_name": "experiment",
+                    "attribute_name": "member",
                 },
             ],
         )
@@ -243,7 +243,7 @@ class AccessOm2Builder(BaseBuilder):
                 r".*/([^/]*)/([^/]*)/output\d+/([^/]*)/.*\.nc", file
             ).groups()
             # configuration = match_groups[0]
-            experiment = match_groups[1]
+            exp_id = match_groups[1]
             realm = match_groups[2]
 
             with xr.open_dataset(file, chunks={}, decode_times=False) as ds:
@@ -251,10 +251,10 @@ class AccessOm2Builder(BaseBuilder):
 
             info = {
                 "path": str(file),
-                "experiment": experiment,
                 "realm": realm,
                 "variable": variable_list,
                 "filename": filename,
+                "member": exp_id,
                 "file_id": file_id,
             }
 
@@ -297,7 +297,7 @@ class AccessEsm15Builder(BaseBuilder):
                 },
                 {
                     "type": "join_new",
-                    "attribute_name": "experiment",
+                    "attribute_name": "member",
                 },
             ],
         )
@@ -321,7 +321,7 @@ class AccessEsm15Builder(BaseBuilder):
             )
 
             match_groups = re.match(r".*/([^/]*)/history/([^/]*)/.*\.nc", file).groups()
-            experiment = match_groups[0]
+            exp_id = match_groups[0]
             realm = match_groups[1]
             if realm == "atm":
                 realm = "atmos"
@@ -335,10 +335,10 @@ class AccessEsm15Builder(BaseBuilder):
 
             info = {
                 "path": str(file),
-                "experiment": experiment,
                 "realm": realm,
                 "variable": variable_list,
                 "filename": filename,
+                "member": exp_id,
                 "file_id": file_id,
             }
 

--- a/src/catalog_manager/esmcat/utils.py
+++ b/src/catalog_manager/esmcat/utils.py
@@ -93,4 +93,4 @@ def strip_pattern_rh(patterns, string):
     stripped = re.sub(r"[-.]", "_", stripped)
 
     # Remove any double or dangling _
-    return re.sub(r"__", "_", stripped).rstrip("_").lstrip("_")
+    return re.sub(r"__", "_", stripped).strip("_")

--- a/src/catalog_manager/esmcat/utils.py
+++ b/src/catalog_manager/esmcat/utils.py
@@ -84,7 +84,7 @@ def strip_pattern_rh(patterns, string):
     # Strip first matched pattern
     stripped = string
     for pattern in patterns:
-        match = re.match(r".*(" + pattern + r")([^0-9]|$).*$", stripped)
+        match = re.match(rf"^.*({pattern}(?!.*{pattern})).*$", stripped)
         if match:
             stripped = stripped[: match.start(1)] + stripped[match.end(1) :]
             break
@@ -93,4 +93,4 @@ def strip_pattern_rh(patterns, string):
     stripped = re.sub(r"[-.]", "_", stripped)
 
     # Remove any double or dangling _
-    return re.sub(r"__", "_", stripped).rstrip("_")
+    return re.sub(r"__", "_", stripped).rstrip("_").lstrip("_")


### PR DESCRIPTION
OM2, ESM1.5 and CM2 Builders now apply `"join_new" aggregation` across "member" attribute that is parsed from the experiment id. This can be used to concatenate multiple ensemble members into a single experiment.

Closes #24 